### PR TITLE
Renome les kinova rules pour contourner un bug avec l'ordre d'executi…

### DIFF
--- a/rules/50-kinova.rules
+++ b/rules/50-kinova.rules
@@ -1,3 +1,0 @@
-
-ATTRS{idVendor}=="22cd", ATTRS{idProduct}=="0000", SYMLINK+="SARA/motors/kinova"
-

--- a/rules/80-kinova.rules
+++ b/rules/80-kinova.rules
@@ -1,0 +1,4 @@
+
+SUBSYSTEMS=="usb", ATTR{manufacturer}=="Kinova inc.", ATTR{product}=="Kinova Robotic Platform", SYMLINK+="SARA/motors/kinova" MODE="0777"
+
+


### PR DESCRIPTION
…on des udevs

Apparement, il fallait pas que le udev rule de kinova soit en position 50.


![dunno](https://media3.giphy.com/media/fFBmVeMTdWWRy/giphy.gif?cid=3640f6095c6de75d5243685445e4aeee)